### PR TITLE
SHA check remote code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ profile
 .DS_Store
 Dependencies/GPGTools_Core
 Dependencies/Libmacgpg
+prepare-core.sh

--- a/CHECKSUM
+++ b/CHECKSUM
@@ -1,0 +1,11 @@
+CHECKSUM:
+
+The SHA256 Checksum of "checksum.rb" should be:
+     c22c89e2b2f21e881f4003991911916e64ffce5753ca40f514a867a62ad4d6b3
+
+The SHA256 Checksum of the downloaded "prepare-core.sh" file should be:
+     b84ceddd3c858bf72e7a5263fd8c67bd9dfe778e4b59a59c071ed772143418cd
+
+The latter is verified for you automatically during install.
+
+**INSERT GPG SIGNATURE OF MAINTAINER HERE**

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAKE_DEFAULT = Dependencies/GPGTools_Core/newBuildSystem/Makefile.default
 
 .PRECIOUS: $(MAKE_DEFAULT)
 $(MAKE_DEFAULT):
-	@bash -c "$$(curl -fsSL https://raw.github.com/GPGTools/GPGTools_Core/master/newBuildSystem/prepare-core.sh)"
+	ruby "checksum.rb"
 
 init: $(MAKE_DEFAULT)
 

--- a/checksum.rb
+++ b/checksum.rb
@@ -1,0 +1,35 @@
+require "fileutils"
+require "digest/sha2"
+
+# The curled script is pinned to a specific git commit **and** should remain so
+# Update this ruby file when the script is updated and generate a new checksum.
+
+unless File.exist?("prepare-core.sh")
+  if !`which #{"curl"}`.empty?
+    `curl -O https://raw.githubusercontent.com/GPGTools/GPGTools_Core/a6e90fa999a930/newBuildSystem/prepare-core.sh`
+  elsif !`which #{"wget"}`.empty?
+    `wget https://raw.githubusercontent.com/GPGTools/GPGTools_Core/a6e90fa999a930/newBuildSystem/prepare-core.sh`
+  else
+    puts "No download tool available! You must have cURL or wget available."
+  end
+end
+
+if !File.exist?("prepare-core.sh")
+  puts "Expected file does not exist. Please check your connection and try again."
+else
+  actual_checksum = Digest::SHA2.hexdigest( File.read("prepare-core.sh") )
+  expected_checksum = "b84ceddd3c858bf72e7a5263fd8c67bd9dfe778e4b59a59c071ed772143418cd"
+
+  puts "Expected Checksum = #{expected_checksum}"
+  puts "Actual Checksum = #{actual_checksum}"
+
+  if actual_checksum.include? expected_checksum
+    puts "Secure Checksum Verification Successful"
+    FileUtils.chmod 0755, "prepare-core.sh"
+    system "bash", "-c", "./prepare-core.sh"
+  else
+    puts "Secure Checksum Verification Failed! DANGER!"
+    FileUtils.rm_f "prepare-core.sh"
+    exit 1
+  end
+end


### PR DESCRIPTION
This utilities Ruby, which exists on all OS X systems (And most Linuxes) to download and sha256 check the downloaded script to ensure it matches the intended checksum, which adds an appreciable level of security over the status quo.

The script is pretty self-explanatory, but it will comfortable work with either cURL or wget. The SHA check is an internal Ruby mechanism, and all the required aspects are natively shipped in every Ruby version OS X supplies, back to at least 10.6, and potentially earlier.

Should Ruby find the checksum to match the expected checksum, it will chmod the file with executable permissions and then hand it over to bash to run. For extra user awareness it will print the checksum
expected and the actual checksum, and then add a "successful verification" message.

Should Ruby find the checksum failing it immediately erases the file and puts a warning the checksum failed, and then exits.

This isn't perfect security, it doesn't pretend to be, but it is a not insignificant step up from the current situation, and may address some of the concerns expressed by Werner on the GPG Mailing lists today and hopefully reacts suitably to some of Lukas' comments as well:

https://lists.gnupg.org/pipermail/gnupg-users/2015-February/052574.html
https://lists.gnupg.org/pipermail/gnupg-users/2015-February/052595.html

The plan to remove the remote execution entirely is a good step, and this can still work with that mechanism very easily, but I thought right now rather than watch drama pile up on the GPG Mailing list I'd try and draw up even a minor improvement to address some of the comments and hopefully be useful in that way.