### PR TITLE
Fix implicit function declaration (build error for Xcode 12+)

### DIFF
--- a/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
+++ b/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
@@ -44,7 +44,7 @@
 #include <utime.h>
 #endif /*HAVE_UTIME_H*/
 
-#include <memory.h>
+#include "memory.h"
 
 #ifdef HAVE_WCHAR_H
 #include <wchar.h>


### PR DESCRIPTION
(Error originally reported at MacPorts: https://trac.macports.org/ticket/61421)

As of Xcode 12, implicit function declarations are errors rather than warnings:
```
GPGTools-pinentry-mac-c5b5260/Source/pinentry-current/pinentry/pinentry-curses.c:1094:4: error:
   implicit declaration of function 'secmem_free' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
           secmem_free (pin_utf8);
           ^
```
For reasons similar to #7, pinentry-curses.c needs to include "memory.h" (rather than <memory.h>) to find the declaration for `secmem_free()`. (On macOS and other BSD OSes, a <memory.h> system header exists and merely includes <string.h>.)