### PR TITLE
Add arm64 to build targets

### DIFF
--- a/pinentry-mac.xcodeproj/project.pbxproj
+++ b/pinentry-mac.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				);
 				PREBINDING = NO;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64 ppc";
+				VALID_ARCHS = "i386 x86_64 ppc arm64";
 			};
 			name = Debug;
 		};
@@ -444,7 +444,7 @@
 				);
 				PREBINDING = NO;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64 ppc";
+				VALID_ARCHS = "i386 x86_64 ppc arm64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This allows pinentry-mac to be built on Apple Silicon with macOS 11.